### PR TITLE
Value types for `mfdcheck`

### DIFF
--- a/src/ControlCore.jl
+++ b/src/ControlCore.jl
@@ -51,6 +51,8 @@ export
   lfd,
   rfd,
   # Methods
+  islfd,
+  isrfd,
   series,
   parallel,
   feedback,

--- a/src/ControlCore.jl
+++ b/src/ControlCore.jl
@@ -74,6 +74,9 @@ include("types/system/generalmimo.jl")
 include("types/system/mfd.jl")
 #include("display.jl")
 
+# Conversions
+include("conversions/mfd2ss.jl")
+
 # Response types
 include("types/response/systemresponse.jl")
 include("types/response/boderesponse.jl")

--- a/src/conversions/mfd2ss.jl
+++ b/src/conversions/mfd2ss.jl
@@ -1,0 +1,164 @@
+# Generates a state space system whose transfer matrix coincides
+# with the one of a matrix fraction description.
+# Based on a column- and row-permuted version of the controller-form
+# realization (Kailath, 1980, Section 6.4.1).
+# NOTE: Base this function on the SLICOT routine TC04AD.
+# NOTE: Is it necessary to make a SISO version of this function?
+function _mfd2ss{S,M1,M2}(mfd::MFD{Siso{false},S,Lfd{false},M1,M2})
+
+  Den, Num  = colred(mfd.D,mfd.N)
+  kden, Phc = high_col_deg_matrix(Den)
+  knum      = col_degree(Num)
+
+  # Check for properness of the MFD (Kailath, 1980, Theorem 6.3-12)
+  all(knum .≤ kden) || error("mfd2ss: MFD is not proper")
+
+  # Normalize the coefficient matrices of Den
+  Phci = inv(Phc)
+  for (k,c) in Den.coeffs
+    Den.coeffs[k] = Phci*Den.coeffs[k]
+  end
+  n  = sum(kden)  # Degree of the state space realization
+  nu = mfd.nu
+  ny = mfd.ny
+
+  # Initialize state space matrices
+  A = zeros(n,n)
+  B = zeros(n,nu)
+  C = zeros(ny,n)
+  D = zeros(ny,nu)
+
+  # Construction of the A and B matrices
+  start_i = 0
+  for i = 1:nu
+
+    start_j = 0
+    for j = 1:nu
+
+      # Add upper diagonal 1's to A
+      if i == j
+        for ii = 1:kden[i]-1
+          A[start_i+ii,start_i+ii+1] = 1
+        end
+      end
+
+      # Add entries of Den to A
+      for l = 0:kden[j]-1
+        A[start_i + kden[i],start_j+l+1] = -Den.coeffs[l][i,j]
+      end
+
+      # Add entries of 1's to B
+      for l = 1:nu
+        B[start_i + kden[i],l] = Phci[i,l]
+      end
+
+      start_j += kden[j]
+    end
+    start_i += kden[i]
+  end
+
+  # Construction of the C and D matrices
+  for i = 1:ny
+
+    start_j = 0
+    for j = 1:nu
+
+      # Add entries of Den to A
+      for l = 0:min(kden[j]-1,knum[j])
+        C[i,start_j+l+1] = Num.coeffs[l][i,j]
+      end
+
+      # Modifications in case column j is biproper
+      if knum[j] == kden[j]
+        for l = 0:kden[j]-1
+          C[i,start_j+l+1] -= Num.coeffs[knum[j]][i,j]*Den.coeffs[l][i,j]
+        end
+        D[i,j] = Num.coeffs[knum[j]][i,j]*Phci[i,l]
+      end
+
+      start_j += kden[j]
+    end
+  end
+
+  return A, B, C, D
+end
+function _mfd2ss{S,M1,M2}(mfd::MFD{Siso{false},S,Lfd{true},M1,M2})
+
+  Den, Num  = rowred(mfd.D,mfd.N)
+  kden, Phr = high_row_deg_matrix(Den)
+  knum      = row_degree(Num)
+
+  # Check for properness of the MFD (Kailath, 1980, Theorem 6.3-12)
+  all(knum .≤ kden) || error("mfd2ss: MFD is not proper")
+
+  # Normalize the coefficient matrices of Den
+  Phri = inv(Phr)
+  for (k,c) in Den.coeffs
+    Den.coeffs[k] = Den.coeffs[k]*Phri
+  end
+  n  = sum(kden)  # Degree of the state space realization
+  nu = mfd.nu
+  ny = mfd.ny
+
+  # Initialize state space matrices
+  A = zeros(n,n)
+  B = zeros(n,nu)
+  C = zeros(ny,n)
+  D = zeros(ny,nu)
+
+  # Construction of the A and C matrices
+  start_i = 0
+  for i = 1:nu
+
+    start_j = 0
+    for j = 1:nu
+
+      # Add upper diagonal 1's to A
+      if i == j
+        for ii = 1:kden[i]-1
+          A[start_i+ii+1,start_i+ii] = 1
+        end
+      end
+
+      # Add entries of Den to A
+      for l = 0:kden[j]-1
+        A[start_j+l+1,start_i + kden[i]] = -Den.coeffs[l][j,i]
+      end
+
+      # Add entries of 1's to B
+      for l = 1:nu
+        C[l,start_i + kden[i]] = Phri[l,i]
+      end
+
+      start_j += kden[j]
+    end
+    start_i += kden[i]
+  end
+
+  # Construction of the B and D matrices
+  for i = 1:ny
+
+    start_j = 0
+    for j = 1:nu
+
+      # Add entries of Den to A
+      for l = 0:min(kden[j]-1,knum[j])
+        B[start_j+l+1,i] = Num.coeffs[l][j,i]
+      end
+
+      # Modifications in case row j is biproper
+      if knum[j] == kden[j]
+        for l = 0:kden[j]-1
+          B[start_j+l+1,i] -= Num.coeffs[knum[j]][j,i]*Den.coeffs[l][j,i]
+        end
+        D[j,i] = Num.coeffs[knum[j]][j,i]*Phri[l,i]
+      end
+
+      start_j += kden[j]
+    end
+  end
+
+  return A, B, C, D
+end
+ss(mfd::MFD{Siso{false},Continuous{true}}) = ss(_mfd2ss(mfd)...)
+ss(mfd::MFD{Siso{false},Continuous{false}}) = ss(_mfd2ss(mfd)...,mfd.Ts)

--- a/src/types/system/mfd.jl
+++ b/src/types/system/mfd.jl
@@ -48,14 +48,14 @@ function mfdcheck{M1<:PolynomialMatrices.PolyMatrix,M2<:PolynomialMatrices.PolyM
   @assert size(N,1) == size(D,1) "MFD: size(N,1) ≠ size(D,1)"
   @assert size(D,1) == size(D,2) "MFD: size(D,1) ≠ size(D,2)"
 
-  return size(N,1), size(D,1)
+  return size(N,1), size(N,2)
 end
 function mfdcheck{M1<:PolynomialMatrices.PolyMatrix,M2<:PolynomialMatrices.PolyMatrix}(
   N::M1, D::M2, ::Type{Lfd{false}})
   @assert size(N,2) == size(D,2) "MFD: size(N,2) ≠ size(D,2)"
   @assert size(D,1) == size(D,2) "MFD: size(D,1) ≠ size(D,2)"
 
-  return size(N,2), size(D,2)
+  return size(N,1), size(N,2)
 end
 function mfdcheck{T<:Bool,M1<:PolynomialMatrices.PolyMatrix,M2<:PolynomialMatrices.PolyMatrix}(
   N::M1, D::M2, ::Type{Lfd{T}}, Ts::Real)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using ControlCore
 using Base.Test
 using PolynomialMatrices
+using Polynomials
 
 # continuous state space type tests
 #include("continuousss.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,20 @@
 using ControlCore
 using Base.Test
-using Polynomials
+using PolynomialMatrices
 
 # continuous state space type tests
-include("continuousss.jl")
-include("dsisorational.jl")
-include("csisorational.jl")
-include("dsisozpk.jl")
-include("csisozpk.jl")
-include("dmimo.jl")
-include("cmimo.jl")
+#include("continuousss.jl")
+#include("dsisorational.jl")
+#include("csisorational.jl")
+#include("dsisozpk.jl")
+#include("csisozpk.jl")
+#include("dmimo.jl")
+#include("cmimo.jl")
+
+## MFDs
+s = Poly([0, 1],:s)
+N = PolyMatrix([s; -s])
+D = PolyMatrix([0 -(s^3+4*s^2+5*s+2); (s+2)^2 s+2])
+M = lfd(N,D)
+@test islfd(M)
+@test !isrfd(M)


### PR DESCRIPTION
### Changes

Short summary of the changes:

This is a sequel to #15, based on a comment from @aytekinar.

- Change 1. As suggested by @aytekinar, here is a proposal for `mfdcheck` based on value types, to avoid transposes (compared to #15).
- Change 2. Added `islfd` and `isrfd`.
- Change 3. Disabled previous tests (since they were based on the old type system), and introduced initial tests for `MFD`.

Cc: @neveritt 